### PR TITLE
fix: Formik submit form not working from Jest test

### DIFF
--- a/client/__mocks__/axios.js
+++ b/client/__mocks__/axios.js
@@ -3,7 +3,6 @@ const defaultResponse = { data: {} };
 
 axios.doMockReset = () => {
   Object.assign(axios, {
-    create: jest.fn(() => axios),
     get: jest.fn().mockImplementationOnce(() => Promise.resolve(defaultResponse)),
     put: jest.fn().mockImplementationOnce(() => Promise.resolve(defaultResponse)),
     post: jest.fn().mockImplementationOnce(() => Promise.resolve(defaultResponse)),
@@ -12,6 +11,6 @@ axios.doMockReset = () => {
   });
 };
 
-axios.doMockReset();
+axios.create = jest.fn(() => axios);
 
 module.exports = axios;

--- a/client/src/components/Profile/Profile.js
+++ b/client/src/components/Profile/Profile.js
@@ -33,8 +33,14 @@ const formikEnhancer = withFormik({
       ),
     confirmPassword: Yup.string().oneOf([Yup.ref('password'), null], 'Passwords must match'),
   }),
+  validate: (values) => {
+    console.log('Formik fn:validate with values:', values);
+  },
   handleSubmit: (payload, { setSubmitting, setErrors, props }) => {
     // TODO: consider putting user in local storage
+
+    console.log('Formik fn:handleSubmit with:', props, payload);
+
     const { user } = props;
     api
       .put(`/users/${user.userId}`, payload, {

--- a/client/src/components/__tests__/profile.test.js
+++ b/client/src/components/__tests__/profile.test.js
@@ -14,26 +14,47 @@ describe('Profile', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('submits form successfully', () => {
-    // TODO: There's a flaw in this test in that it doesn't validate any of the fields.
-    // In fact, setting the fields has nothing to do with whether test passes or not.
-    const { findByLabelText, getByText } = render(<Profile />);
-    const firstName = findByLabelText('first name');
-    firstName.value = 'Michaux';
-    const lastName = findByLabelText('last name');
-    lastName.value = 'Kelley';
-    const email = findByLabelText('email');
-    email.value = 'test@test.com';
+  it('submits form successfully', async () => {
+    // Pass a fake user with formik default values for use in mapPropsToValues
+    const user = { userId: 1, firstName: '', lastName: '', email: '' };
+
+    const { getByText, getByLabelText } = render(<Profile user={user} />);
+
+    const firstName = getByLabelText(/first name/i);
+    const lastName = getByLabelText(/last name/i);
+    const email = getByLabelText(/email/i);
     const submit = getByText('Submit');
 
-    // No need to add mockImplementationOnce,
-    // we're doing it directly inside the custom mock file
+    await waitFor(() => {
+      fireEvent.change(firstName, {
+        target: {
+          value: "Michaux"
+        }
+      });
+    });
+
+    await waitFor(() => {
+      fireEvent.change(lastName, {
+        target: {
+          value: "Kelley"
+        }
+      });
+    });
+
+    await waitFor(() => {
+      fireEvent.change(email, {
+        target: {
+          value: "test@test.com"
+        }
+      });
+    });
 
     fireEvent.click(submit);
 
-    waitFor(() => {
+    await waitFor(() => {
       expect(mockAxios.put).toHaveBeenCalledTimes(1);
-    });
+    })
+
   });
 
   // This test should pass, but instead gives error: Unable to find the "window" object for the given node.


### PR DESCRIPTION
Merge and check if this PR is working.

I have tested it and it calls Formik validation. For example, if you put an invalid email, it will not pass.

I have included 2 `console.logs` inside [`Profile.js`](https://github.com/mkelley33/pws-gatsby/pull/2/commits/e955c2509f704a4e5bdde390247a47ec849caa3a#diff-df0232b506c191a07c5e312b600ef006) in [`validate`](https://github.com/mkelley33/pws-gatsby/pull/2/commits/e955c2509f704a4e5bdde390247a47ec849caa3a#diff-df0232b506c191a07c5e312b600ef006R37) and in [`handleSubmit`](https://github.com/mkelley33/pws-gatsby/pull/2/commits/e955c2509f704a4e5bdde390247a47ec849caa3a#diff-df0232b506c191a07c5e312b600ef006R42). These are just for demontration that the validation passes. You will remove them after you check it's working as expected.